### PR TITLE
maven-publish-action: refactored to use the internal github release branch name

### DIFF
--- a/.github/workflows/build-publish-deploy.yml
+++ b/.github/workflows/build-publish-deploy.yml
@@ -40,7 +40,7 @@ jobs:
             RELEASE_VERSION: ${{ github.ref }}
             GITHUB_USERNAME: ${{ secrets.USERNAME }}
             GITHUB_TOKEN: ${{ secrets.TOKEN }}
-          run: chmod +rwx ./maven-publish.sh && ./maven-publish.sh
+          run: echo $RELEASE_VERSION && chmod +rwx ./maven-publish.sh && ./maven-publish.sh
           
         - name: Setup Pages
           uses: actions/configure-pages@v2

--- a/.github/workflows/build-publish-deploy.yml
+++ b/.github/workflows/build-publish-deploy.yml
@@ -37,10 +37,9 @@ jobs:
           
         - name: Publish to apache maven
           env:
-            RELEASE_VERSION: ${{ github.ref }}
             GITHUB_USERNAME: ${{ secrets.USERNAME }}
             GITHUB_TOKEN: ${{ secrets.TOKEN }}
-          run: echo $RELEASE_VERSION && chmod +rwx ./maven-publish.sh && ./maven-publish.sh
+          run: chmod +rwx ./maven-publish.sh && ./maven-publish.sh
           
         - name: Setup Pages
           uses: actions/configure-pages@v2

--- a/.github/workflows/build-publish-deploy.yml
+++ b/.github/workflows/build-publish-deploy.yml
@@ -37,6 +37,7 @@ jobs:
           
         - name: Publish to apache maven
           env:
+            RELEASE_VERSION: ${{ github.ref }}
             GITHUB_USERNAME: ${{ secrets.USERNAME }}
             GITHUB_TOKEN: ${{ secrets.TOKEN }}
           run: chmod +rwx ./maven-publish.sh && ./maven-publish.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p>  <a href="https://software-hardware-codesign.github.io/Serial4j-v1/serial4j-0.3A-javadoc/index.html"> <img src="https://github.com/Software-Hardware-Codesign/Serial4j-v1/blob/master/serial-4j-rounded-corners.png" height=80 width=100/> </a> </p> 
+<p>  <a href="https://software-hardware-codesign.github.io/Serial4j-v1/serial4j-0.3A-javadoc/index.html"> <img src="https://github.com/Software-Hardware-Codesign/Serial4j-v1/blob/development/serial-4j-rounded-corners.png" height=80 width=100/> </a> </p> 
 
 [![](https://github.com/Software-Hardware-Codesign/Serial4j-v1/actions/workflows/build-publish-deploy.yml/badge.svg)](https://github.com/Software-Hardware-Codesign/Serial4j-v1/actions)
 

--- a/build/assemble/variables.sh
+++ b/build/assemble/variables.sh
@@ -12,7 +12,7 @@ canonical_link=`readlink -f ${0}`
 assemble_dir=`dirname $canonical_link`
 
 jar_folder='serial4j'
-version_number=$RELEASE_VERSION
+version_number=$GITHUB_REF_NAME
 jar=${jar_folder}'.jar'
 
 java_docs_folder=$jar_folder'-'$version_number'-javadoc'

--- a/build/assemble/variables.sh
+++ b/build/assemble/variables.sh
@@ -12,7 +12,7 @@ canonical_link=`readlink -f ${0}`
 assemble_dir=`dirname $canonical_link`
 
 jar_folder='serial4j'
-version_number='0.3A'
+version_number=$RELEASE_VERSION
 jar=${jar_folder}'.jar'
 
 java_docs_folder=$jar_folder'-'$version_number'-javadoc'

--- a/maven-publish.sh
+++ b/maven-publish.sh
@@ -34,7 +34,7 @@ function deploy() {
 
 function publish() {
 	groupId="com.avrsandbox.serial4j"
-	version="0.3-Alpha"
+	version=$GITHUB_REF_NAME
 	url="https://maven.pkg.github.com/Software-Hardware-Codesign/Serial4j-v1"
 
 	files=(`cd "${project_dir}/output/serial4j" && ls *.jar && cd "${project_dir}"`)


### PR DESCRIPTION
Refactored `maven-publish.sh` and `./build/assemble/variables.sh` to use the internal github release branch environmental variable `GITHUB_REF_NAME` in the assemble and publish jobs.